### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/rwsdevops/6cca62ef-5ce3-4b00-9b16-b1ffb9ba8491/7a052d91-b7c4-4ec1-bdda-e3946838234f/_apis/work/boardbadge/bf1592be-c1f1-492a-9e73-849119781a2e)](https://dev.azure.com/rwsdevops/6cca62ef-5ce3-4b00-9b16-b1ffb9ba8491/_boards/board/t/7a052d91-b7c4-4ec1-bdda-e3946838234f/Microsoft.RequirementCategory)
 # AZ-104
 A repo for tracking my notes, templates and scripts for the Azure AZ-104 certifications. 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/rwsdevops/6cca62ef-5ce3-4b00-9b16-b1ffb9ba8491/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.